### PR TITLE
Add possibility for attributions to all images

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,27 @@ sections:
         target_blank: true # Whether or not the link to the video script or slides is external or not (almost always true)
 ```
 
+### Image Attributions:
+
+Adding an Attribution (copyright information) to an image:
+
+1. Locate the file where the image url is set (usually a markdown file under `/src/content`, sometimes a yml file under `/src/data`). It should look something like this:
+
+```yml
+- img_back: "/path/to/image.png" # The path to the image
+  partial: "imgs-text.html" # The partial used to render these fields
+  # Other optional fields like title, description, ...
+```
+
+2. Add a field `img_credit` with the text of the attribution like this:
+   
+```yml
+- img_back: "/path/to/image.png" # The path to the image
+  img_credit: "© Max Mustermann" # The image attribution
+  partial: "imgs-text.html" # The partial used to render these fields
+  # Other optional fields like title, description, ...
+```
+
 ## Add Web Components
 
 Adding Web Components **from the Web Component store** to the layout of a page is simple. 
@@ -280,27 +301,6 @@ On local development and on testingmachine deploys this Web Component would rend
 ```
 
 On production deploys the url will point to the production script of the Web Component.
-
-## Image Attributions
-
-Adding an Attribution (copyright information) to an image:
-
-1. Locate the file where the image url is set (usually a markdown file under `/src/content`, sometimes a yml file under `/src/data`). It should look something like this:
-
-```yml
-- img_back: "/path/to/image.png" # The path to the image
-  partial: "imgs-text.html" # The partial used to render these fields
-  # Other optional fields like title, description, ...
-```
-
-2. Add a field `img_credit` with the text of the attribution like this:
-   
-```yml
-- img_back: "/path/to/image.png" # The path to the image
-  img_credit: "© Max Mustermann" # The image attribution
-  partial: "imgs-text.html" # The partial used to render these fields
-  # Other optional fields like title, description, ...
-```
 
 ## Information
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Repository for the [Open Data Hub](https://opendatahub.com/) website created wit
   - [Videos](#videos)
     - [Video sections](#add-new-sections)
     - [Individual videos](#add-new-videos)
+  - [Image Attributions](#image-attributions)
 - [Add Web Components](#add-web-components)
 - [Docker environment](#docker-environment)
 - [Information](#information)
@@ -279,6 +280,27 @@ On local development and on testingmachine deploys this Web Component would rend
 ```
 
 On production deploys the url will point to the production script of the Web Component.
+
+## Image Attributions
+
+Adding an Attribution (copyright information) to an image:
+
+1. Locate the file where the image url is set (usually a markdown file under `/src/content`, rarely a html file under `/src/themes/odh-fbe/layouts/page-name/list.html`). It should look something like this:
+
+```yml
+- img_back: "/path/to/image.png" # The path to the image
+  partial: "imgs-text.html" # The partial used to render these fields
+  # Other optional fields like title, description, ...
+```
+
+2. Add a field `img_credit` with the text of the attribution like this:
+   
+```yml
+- img_back: "/path/to/image.png" # The path to the image
+  img_credit: "© Max Mustermann" # The image attribution
+  partial: "imgs-text.html" # The partial used to render these fields
+  # Other optional fields like title, description, ...
+```
 
 ## Information
 

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ On production deploys the url will point to the production script of the Web Com
 
 Adding an Attribution (copyright information) to an image:
 
-1. Locate the file where the image url is set (usually a markdown file under `/src/content`, rarely a html file under `/src/themes/odh-fbe/layouts/page-name/list.html`). It should look something like this:
+1. Locate the file where the image url is set (usually a markdown file under `/src/content`, sometimes a yml file under `/src/data`). It should look something like this:
 
 ```yml
 - img_back: "/path/to/image.png" # The path to the image

--- a/src/themes/odh-fbe/layouts/partials/_img-credited.html
+++ b/src/themes/odh-fbe/layouts/partials/_img-credited.html
@@ -1,3 +1,9 @@
+{{/*
+	SPDX-FileCopyrightText: NOI Techpark <digital@noi.bz.it>
+
+	SPDX-License-Identifier: AGPL-3.0-or-later
+*/}}
+
 <div class="position-relative">
   {{ with .img_credit }}
   <div class="position-absolute end-0 bottom-0 py-1 px-2 opacity-75">

--- a/src/themes/odh-fbe/layouts/partials/_img-credited.html
+++ b/src/themes/odh-fbe/layouts/partials/_img-credited.html
@@ -1,0 +1,8 @@
+<div class="position-relative">
+  {{ with .img_credit }}
+  <div class="position-absolute end-0 bottom-0 py-1 px-2 opacity-75">
+    <small class="bg-white rounded-1 py-0 px-1">{{ . }}</small>
+  </div>
+  {{ end }}
+  <img src="{{ .img_back }}" />
+</div>

--- a/src/themes/odh-fbe/layouts/partials/img-enlargeable.html
+++ b/src/themes/odh-fbe/layouts/partials/img-enlargeable.html
@@ -8,12 +8,12 @@
   <div
       data-bs-toggle="modal"
       data-bs-target="#modal-{{ .img_back | sha1 }}"
-      class="enlarge-overlay bg-secondary-subtle position-absolute w-100 h-100 d-none d-lg-flex gap-2 align-items-center justify-content-center text-white"
+      class="enlarge-overlay bg-secondary-subtle position-absolute w-100 h-100 d-none d-lg-flex gap-2 align-items-center justify-content-center text-white z-1"
   >
       <span>Click to enlarge</span>
       <i class="fa fa-search" aria-hidden="true" id="magnifying-glass"></i>
   </div>
-  <img src="{{ .img_back }}" />
+  {{ partial "_img-credited.html" . }}
 </div>
 <div class="modal modal-lg fade" id="modal-{{ .img_back | sha1 }}" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered">
@@ -26,12 +26,7 @@
           >
               <button class="btn-close"></button>
           </div>
-          {{ with .img_credit }}
-          <div class="position-absolute end-0 bottom-0 p-2">
-            <span class="bg-white py-1 px-2 rounded">{{ . }}</span>
-          </div>
-          {{ end }}
-          <img src="{{ .img_back }}" />
+          {{ partial "_img-credited.html" . }}
       </div>
   </div>
 </div>

--- a/src/themes/odh-fbe/layouts/partials/imgs-icon-text.html
+++ b/src/themes/odh-fbe/layouts/partials/imgs-icon-text.html
@@ -10,8 +10,8 @@
 		<div class="row gy-4 justify-content-between align-items-center py-4">
 			<div class="col-12 col-lg-5 m-lg-0 text-center text-lg-end">
 				<div class="position-relative">
-					<img class="w-25 position-absolute bottom-0 start-0 p-2 p-xl-3 p-lg-2" src="{{ .img_front }}"/>
-					<img src="{{ .img_back }}"/>
+					<img class="w-25 position-absolute bottom-0 start-0 p-2 p-xl-3 p-lg-2 z-1" src="{{ .img_front }}"/>
+					{{ partial "_img-credited.html" . }}
 				</div>
 			</div>
 			<div class="col-12 col-lg-6 m-lg-0">

--- a/src/themes/odh-fbe/layouts/partials/imgs-text.html
+++ b/src/themes/odh-fbe/layouts/partials/imgs-text.html
@@ -9,7 +9,7 @@
 	<div class="container">
 		<div class="row gy-4 justify-content-between align-items-center py-4">
 			<div class="col-12 col-lg-5 m-lg-0 text-center text-lg-end">
-				<img src="{{ .img_back }}"/>
+				{{ partial "_img-credited.html" . }}
 			</div>
 			<div class="col-12 col-lg-6 m-lg-0">
 				{{ with .subtitle }}<span class="fw-semibold fs-5">{{ . | markdownify }}</span>{{ end }}

--- a/src/themes/odh-fbe/layouts/partials/imgs.html
+++ b/src/themes/odh-fbe/layouts/partials/imgs.html
@@ -7,6 +7,10 @@
 <section>
     <div class="container">
         <div class="row">
+            {{/*
+                This image is not using the credited image partial as it has custom classes,
+                however, this partial is currently not used.
+            */}}
             <img src="{{ .img_back }}" class="w-75 h-auto rounded mx-auto d-block"/> 
         </div>
     </div>

--- a/src/themes/odh-fbe/layouts/partials/scroll-imgs.html
+++ b/src/themes/odh-fbe/layouts/partials/scroll-imgs.html
@@ -9,7 +9,7 @@
     <div class="container">
         <div class="col-12">
             <div class="text-center" style=" overflow-Y: scroll;">
-                <img src="{{ .img_back }}" class="img-back " /> 
+                {{ partial "_img-credited.html" . }}
             </div> 
         </div>
     </div>

--- a/src/themes/odh-fbe/layouts/partials/single-col-imgs-text.html
+++ b/src/themes/odh-fbe/layouts/partials/single-col-imgs-text.html
@@ -14,7 +14,7 @@
         </div>
         <div class="row">
             <div class="col-12">
-                <img src="{{ .img_back }}"/> 
+                {{ partial "_img-credited.html" . }}
             </div>
         </div>
     </div>

--- a/src/themes/odh-fbe/layouts/partials/text-imgs-icon.html
+++ b/src/themes/odh-fbe/layouts/partials/text-imgs-icon.html
@@ -19,8 +19,8 @@
 			</div>
 			<div class="col-12 col-lg-5 m-lg-0">
 				<div class="position-relative">
-					<img class="w-25 position-absolute bottom-0 end-0 p-2 p-xl-3 p-lg-2" src="{{ .img_front }}"/>
-					<img src="{{ .img_back }}"/>
+					<img class="w-25 position-absolute bottom-0 end-0 p-2 p-xl-3 p-lg-2 z-1" src="{{ .img_front }}"/>
+					{{ partial "_img-credited.html" . }}
 				</div>
 			</div>
 		</div>

--- a/src/themes/odh-fbe/layouts/partials/text-imgs-long.html
+++ b/src/themes/odh-fbe/layouts/partials/text-imgs-long.html
@@ -14,7 +14,7 @@
 				
 			</div>
 			<div class="col-12 col-lg-6 imgs">
-				<img src="{{ .img_back }}" class="img-back" />
+				{{ partial "_img-credited.html" . }}
 			</div>
 	</div>
 </section>

--- a/src/themes/odh-fbe/layouts/partials/text-imgs.html
+++ b/src/themes/odh-fbe/layouts/partials/text-imgs.html
@@ -18,7 +18,7 @@
 				{{ end }}
 			</div>
 			<div class="col-12 col-lg-5 m-lg-0 text-center text-lg-end">
-				<img src="{{ .img_back }}"/>
+				{{ partial "_img-credited.html" . }}
 			</div>
 		</div>
 	</div>

--- a/src/themes/odh-fbe/layouts/partials/title-cta.html
+++ b/src/themes/odh-fbe/layouts/partials/title-cta.html
@@ -21,7 +21,7 @@
                 {{ if isset . "video"}}
                 {{ partial "video-iframe.html" . }}
                 {{ else }}
-                <img src="{{ .img_back }}" />
+                {{ partial "_img-credited.html" . }}
                 {{ end }}
             </div>
         </div>


### PR DESCRIPTION
I added the possibility to add attributions to all images by simply adding a field `img_credit`.

Regarding the impementation, to avoid repetition, I created a new partial, **intended only to be used by other partials and not to be used directly as a section on the site**. Therefore I prefixed it with an underscore.
Where possible I replaced the `<img />` tag with `{{ partial "_img-credited.html" . }}`. This automatically adds the attribution to the image (if the `img_credit` field is present).
Note: Due to `<img />` tags being rendered diffrently than `<div />` tags, when using an overlay over the image it has to be explicitly moved over the attributed image by adding the `z-1` class to the overlay. An example for this can be found in the `img-enlargeable.html` partial.

Information on how to add the `img_credit` field can be found in the documentation.