### PR TITLE
Fix "Go to Top" button

### DIFF
--- a/src/themes/odh-fbe/layouts/_default/baseof.html
+++ b/src/themes/odh-fbe/layouts/_default/baseof.html
@@ -11,7 +11,7 @@
   </head>
 
   <body>
-    <a id="top"></a>
+    <a id="top" class="position-absolute top-0"></a>
     {{ partial "spinner.html" . }}
 
     {{ partial "nav.html" . }}


### PR DESCRIPTION
I noticed a mistake where the gototop button does not scroll the website to the very top but only to just under the navbar.
I fixed it by giving the ```#top``` anchor (which the gototop anchor links to) an absolute position at the top of the website.