### PR TITLE
Anchor link for pricing section

### DIFF
--- a/src/themes/odh-fbe/layouts/services/single/list.html
+++ b/src/themes/odh-fbe/layouts/services/single/list.html
@@ -15,8 +15,13 @@
 {{ end }}
 
 {{ if isset .Params "show_table" }}
-    {{ partial "title.html" site.Data.services.pricing }}
-    {{ partial "table-comparison.html" site.Data.services.pricing}}
+    {{ $anchor := "pricing" }}
+    <h2 id="{{ $anchor }}">
+        <a href="#{{ $anchor }}">
+            {{ partial "title.html" site.Data.services.pricing }}
+        </a>
+    </h2>
+    {{ partial "table-comparison.html" site.Data.services.pricing }}
 {{ end }}
 
 {{ end }}


### PR DESCRIPTION
I added an anchor link and a corresponding `href` to make the title of the pricing section clickable, as suggested in the following ticket: https://issues.opendatahub.com/Ticket/Display.html?id=17096.

For local testing, the new anchor link is: http://127.0.0.1:1313/services/data-access/#pricing.
