### PR TITLE
fix title and add dark background

### DIFF
--- a/src/content/services/certification/_index.md
+++ b/src/content/services/certification/_index.md
@@ -5,7 +5,7 @@ aliases: /certification
 title: "Open Data Hub API Certified Technology Provider"
 
 rows:
-  - title: "<u>How to be certified?</u>"
+  - title: "How to be certified?"
     description: >
       1. Send a request to us to be certified. Do include the following details:
           
@@ -18,6 +18,7 @@ rows:
       3. The Open Data Hub team verifies the compatibility and that the data gets collected in out Testing Environment.
       
       4. The Open Data Hub team sends a certificate of compatibility and adds your organization to the Certified Technology Provider register on OpenDataHub.com.
+    bg_darker: true
     partial: text-contact.html
     contact_email: "help@opendatahub.com"
 

--- a/src/themes/odh-fbe/layouts/partials/text-contact.html
+++ b/src/themes/odh-fbe/layouts/partials/text-contact.html
@@ -6,17 +6,13 @@
 	
 {{"<!-- Double Column Text - Imgs -->" | safeHTML }}
 <section>
-	<div class="container">
-		<div class="col-12">
-			<h2>{{ .title | markdownify }}</h2>
-			<p>{{ .description | markdownify }}</p>
-		</div>
-	</div>
-</section>
-<section>
-	<div class="container">
-		<div class="row">
-            {{ partial "contact-mailto.html" . }}
+	<div class="justify-content-between py-4">
+		<div class="container">
+			<div class="col-12">
+				<h2>{{ .title | markdownify }}</h2>
+				<p>{{ .description | markdownify }}</p>
+				{{ partial "contact-mailto.html" . }}
+			</div>
 		</div>
 	</div>
 </section>


### PR DESCRIPTION
## Changes Made

- Remove underline from heading "How to be certified?"
- Make background of section darker, with reference to `services/data-access/`

<img width="1080" alt="image" src="https://github.com/user-attachments/assets/902bbe8a-46ed-438a-89c4-9a2453d3c264">
