### PR TITLE
Add quota information to pricing

### DIFF
--- a/src/data/services.yml
+++ b/src/data/services.yml
@@ -45,6 +45,19 @@ pricing:
       color_class: bg-pro
   row:
     - cols:
+        - content: "<a href='https://github.com/noi-techpark/odh-docs/wiki/Historical-Data-and-Request-Rate-Limits'><u>Maximum request period for historical data</u></a>"
+        - content: "5 days - 100 days"
+        - content: "1000 days"
+        - content: "unlimited"
+        - content: "unlimited"
+    - cols:
+        - content: "<a href='https://github.com/noi-techpark/odh-docs/wiki/Request-Rate-Limits'><u>Requests per Second</u></a>"
+        - content: "10 - 20"
+        - content: "50"
+        - content: "100"
+        - content: "200"
+
+    - cols:
         - content: Access to all Open Data provided
         - content: "&#10004;"
         - content: "&#10004;"

--- a/src/data/services.yml
+++ b/src/data/services.yml
@@ -51,12 +51,11 @@ pricing:
         - content: "unlimited"
         - content: "unlimited"
     - cols:
-        - content: "<a href='https://github.com/noi-techpark/odh-docs/wiki/Request-Rate-Limits'><u>Requests per Second</u></a>"
+        - content: "<a href='https://github.com/noi-techpark/odh-docs/wiki/Historical-Data-and-Request-Rate-Limits'><u>Requests per Second</u></a>"
         - content: "10 - 20"
         - content: "50"
         - content: "100"
         - content: "200"
-
     - cols:
         - content: Access to all Open Data provided
         - content: "&#10004;"


### PR DESCRIPTION
For testing, check out: http://localhost:1313/services/data-access/#pricing

___

I added information on historical data request limits and requests per second to the pricing table.  
![image](https://github.com/user-attachments/assets/ab525371-1458-4e0c-aead-702a90888c48)

For the UNREGISTERED section, I put both with and without referrer information in one cell.  
I tried adding labels like "with Referrer Information" but it didn’t look good, so I only included the two values in one cell and linked the wiki article: https://github.com/noi-techpark/odh-docs/wiki/Historical-Data-and-Request-Rate-Limits to make it easy to understand.
