### PR TITLE
Transmodel API quick start boxes

### DIFF
--- a/src/data/quickstart.yml
+++ b/src/data/quickstart.yml
@@ -7,6 +7,10 @@ boxes:
     subtitle: Browse and discover the available data.
     btn_link: https://databrowser.opendatahub.com
 
+  - title: Transmodel API - NeTEx Endpoints
+    subtitle: Access standardized planned mobility data including public transport, parking, and sharing services in NeTEx format.
+    btn_link: https://github.com/noi-techpark/odh-docs/wiki/Transmodel-API-%E2%80%90-NeTEx-Endpoints
+
   - title: Analytics Tool
     subtitle: Find out information about sensors and their locations and measure (near-real time data).
     btn_link: https://analytics.opendatahub.com

--- a/src/data/quickstart.yml
+++ b/src/data/quickstart.yml
@@ -11,6 +11,10 @@ boxes:
     subtitle: Access standardized planned mobility data including public transport, parking, and sharing services in NeTEx format.
     btn_link: https://github.com/noi-techpark/odh-docs/wiki/Transmodel-API-%E2%80%90-NeTEx-Endpoints
 
+  - title: Transmodel API - SIRI-Lite Endpoints
+    subtitle: Retrieve real-time data for parking and sharing services using the SIRI-Lite protocol.
+    btn_link: https://github.com/noi-techpark/odh-docs/wiki/Transmodel-API-%E2%80%90-SIRI%E2%80%90Lite-Endpoints
+
   - title: Analytics Tool
     subtitle: Find out information about sensors and their locations and measure (near-real time data).
     btn_link: https://analytics.opendatahub.com


### PR DESCRIPTION
I added two boxes for the new Transmodel API in our quick-start section to give them more visibility. The boxes link to the following Wiki articles, which provide the necessary context for users and include links to the project's README and the Swagger documentation:

- https://github.com/noi-techpark/odh-docs/wiki/Transmodel-API-%E2%80%90-NeTEx-Endpoints
- https://github.com/noi-techpark/odh-docs/wiki/Transmodel-API-%E2%80%90-SIRI%E2%80%90Lite-Endpoints  
(These can also be accessed via our Wiki homepage: https://github.com/noi-techpark/odh-docs/wiki > Transmodel API)

@rcavaliere Let me know if you’d like any changes or have other feedback. :)

As I’m currently working on the API overview page, this is a temporary solution. We will move the information about the individual APIs we offer to the new page to clean up the quick-start section.



![Screenshot 2024-10-17 175242](https://github.com/user-attachments/assets/b88d4a30-a0b3-4523-8a32-84d9185c3445)
