### PR TITLE
Seo fields header

### DIFF
--- a/src/content/use-cases/arxax.md
+++ b/src/content/use-cases/arxax.md
@@ -7,6 +7,12 @@ use_case_tags:
   - "mobility"
   - "traffic"
 
+seo:
+  title:
+  description:
+  keywords:
+
+
 short:
   subtitle: "ARXAX"
   title: "**Re-envisioning transportation & the green fuel supply chain.**"

--- a/src/content/use-cases/bikebox.md
+++ b/src/content/use-cases/bikebox.md
@@ -7,6 +7,11 @@ use_case_tags:
   - "mobility"
   - "traffic"
 
+seo:
+  title: "Südtirolmobil Bikebox"
+  description: "Südtirolmobil Bikeboxes are safe storage spaces for bicycles. The bike boxes service is seamlessly integrated with the Südtirolmobil scheme, further enhancing the Mobility as a Service (MaaS) perspective in the region. Cyclists with a Südtirol Pass can now utilize a single application to access a multitude of mobility services, ranging from public transportation to bike parking facilities, streamlining their travel experience."
+  keywords: "mobility, traffic, Südtirolmobil, Bikebox, MaaS, Südtirol Pass, bike parking facilities, public transportation, Open Data Hub"
+
 short:
   subtitle: "SÜDTIROLMOBIL BIKEBOX"
   title: "**Cyclists' mobility made easy**"

--- a/src/content/use-cases/brennerLEC.md
+++ b/src/content/use-cases/brennerLEC.md
@@ -7,6 +7,11 @@ use_case_tags:
   - "traffic"
   - "mobility"
 
+seo:
+  title:
+  description:
+  keywords:
+
 short:
   subtitle: "BRENNERLEC"
   title: "**Brenner Lower Emissions Corridor**"

--- a/src/content/use-cases/contributor-of-the-year.md
+++ b/src/content/use-cases/contributor-of-the-year.md
@@ -7,6 +7,11 @@ use_case_tags:
   - "traffic"
   - "mobility"
 
+seo:
+  title:
+  description:
+  keywords:
+
 short:
   subtitle: "OPEN DATA HUB"
   title: "**Contributor of the year 2024**"

--- a/src/content/use-cases/ert-map.md
+++ b/src/content/use-cases/ert-map.md
@@ -6,6 +6,10 @@ aliases:
 use_case_tags:
   - "tourism"
 
+seo:
+  title:
+  description:
+  keywords:
 
 short:
   subtitle: "ËRT - Moritz Brunner"

--- a/src/content/use-cases/green-mobility.md
+++ b/src/content/use-cases/green-mobility.md
@@ -7,6 +7,11 @@ use_case_tags:
   - "traffic"
   - "mobility"
 
+seo:
+  title:
+  description:
+  keywords:
+
 short:
   subtitle: "GREENMOBILITY"
   title: "**Real-time e-charging stations**"

--- a/src/content/use-cases/kultivas.md
+++ b/src/content/use-cases/kultivas.md
@@ -6,6 +6,11 @@ aliases:
 use_case_tags:
   - "agriculture"
 
+seo:
+  title:
+  description:
+  keywords:
+
 short:
   subtitle: "KULTIVAS"
   title: "**Big data technologies and apples**"

--- a/src/content/use-cases/mentor.md
+++ b/src/content/use-cases/mentor.md
@@ -6,6 +6,11 @@ aliases:
 use_case_tags:
   - "mobility"
 
+seo:
+  title:
+  description:
+  keywords:
+
 short:
   subtitle: "MENTOR"
   title: "**Mobility-as-a-Service: the new mobility of Merano**"

--- a/src/content/use-cases/meranoapp.md
+++ b/src/content/use-cases/meranoapp.md
@@ -7,6 +7,11 @@ use_case_tags:
   - "mobility"
   - "traffic"
 
+seo:
+  title:
+  description:
+  keywords:
+
 short:
   subtitle: "MERANO APP"
   title: "**Enhancing Tourist and Local Experiences**"

--- a/src/content/use-cases/ontopic.md
+++ b/src/content/use-cases/ontopic.md
@@ -6,6 +6,11 @@ use_case_tags:
   - "mobility"
   - "traffic"
 
+seo:
+  title:
+  description:
+  keywords:
+
 short:
   subtitle: "ONTOPIC"
   title: "**Revolutionising Data Access with SPARQL Endpoint and Virtual Knowledge Graph**"

--- a/src/content/use-cases/skyalps.md
+++ b/src/content/use-cases/skyalps.md
@@ -6,6 +6,11 @@ aliases:
 use_case_tags:
   - "mobility"
 
+seo:
+  title:
+  description:
+  keywords:
+
 short:
   subtitle: "SKYALPS"
   title: "**Real-time flight data**"

--- a/src/content/use-cases/suedtirolmobil.md
+++ b/src/content/use-cases/suedtirolmobil.md
@@ -6,6 +6,11 @@ aliases:
 use_case_tags:
   - "mobility"
 
+seo:
+  title:
+  description:
+  keywords:
+
 short:
   subtitle: "SÜDTIROLMOBIL - ALTOADIGEMOBILITÀ"
   title: "**Public mobility of the future**"

--- a/src/content/use-cases/today_eurac.md
+++ b/src/content/use-cases/today_eurac.md
@@ -6,6 +6,11 @@ aliases:
 use_case_tags:
   - "eurac"
 
+seo:
+  title:
+  description:
+  keywords:
+
 short:
   subtitle: "TODAY@EURAC"
   title: "**Enhancing Event Visibility through Data Visualization at Eurac**"

--- a/src/themes/odh-fbe/layouts/partials/header.html
+++ b/src/themes/odh-fbe/layouts/partials/header.html
@@ -6,13 +6,29 @@
 
 <meta charset="utf-8" />
 <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-<title>{{ .Site.Title }}</title>
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <!-- <meta name="keywords" content="free html5, free template, free bootstrap, html5, css3, mobile first, responsive, hugo, static site" /> -->
 {{ with .Site.Params.author }}
 <meta name="author" content="{{ . }}" />{{ end }}
-{{ with .Site.Params.description }}
-<meta name="description" content="{{ . }}" />{{ end }} {{ with .Site.LanguageCode }}
+
+<!-- SEO fields -->
+{{ with .File }}
+  {{ with site.GetPage .Path }}
+    {{ with .Params.seo.title }}
+      <title>{{ . }}</title>
+    {{ else }}
+      <title>{{ .Site.Title }}</title>
+    {{ end }}
+    {{ with .Params.seo.description }}
+      <meta name="description" content="{{ . }}" />
+    {{ end }}
+    {{ with .Params.seo.keywords }}
+      <meta name="keywords" content="{{ . }}" />
+    {{ end }}
+  {{ end }} 
+{{ end }} 
+
+{{ with .Site.LanguageCode }}
 <meta http-equiv="content-language" content="{{ . }}" />{{ end }}
 {{ if .Site.Params.noindex }}
 <meta name="robots" content="noindex,nofollow">


### PR DESCRIPTION
Add logic to add meta tags to header from content files.
Issue: #259



Example:
```
seo:
  title: "Südtirolmobil Bikebox"
  description: "Südtirolmobil Bikeboxes are safe storage spaces for bicycles. The bike boxes service is seamlessly integrated with the Südtirolmobil scheme, further enhancing the Mobility as a Service (MaaS) perspective in the region. Cyclists with a Südtirol Pass can now utilize a single application to access a multitude of mobility services, ranging from public transportation to bike parking facilities, streamlining their travel experience."
  keywords: "mobility, traffic, Südtirolmobil, Bikebox, MaaS, Südtirol Pass, bike parking facilities, public transportation, Open Data Hub"

```

![image](https://github.com/user-attachments/assets/bc46e284-26de-4946-9a49-300271662a03)
