### PR TITLE
Fixes to styling of the website to follow style guidelines properly

### DIFF
--- a/src/config/_default/config.yml
+++ b/src/config/_default/config.yml
@@ -21,9 +21,9 @@ params:
       script_name: datasets-list-widget.min.js
       attributes:
         - key: font-url
-          value: https://fonts.testingmachine.eu/open-sans/style.css
+          value: https://fonts.testingmachine.eu/source-sans-pro/style.css
         - key: font-name
-          value: Open Sans
+          value: Source Sans Pro
 
     wcs_list_widget:
       tag_name: wcs-list-widget
@@ -31,9 +31,9 @@ params:
       script_name: wcs-list-widget.min.js
       attributes:
         - key: font-url
-          value: https://fonts.testingmachine.eu/open-sans/style.css
+          value: https://fonts.testingmachine.eu/source-sans-pro/style.css 
         - key: font-name
-          value: Open Sans
+          value: Source Sans Pro
 
   noindex: false
   logo: img/NOI_OPENDATAHUB_NEW_BK_nospace-01.svg
@@ -54,7 +54,6 @@ params:
       - URL: https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css
       - URL: https://scripts.opendatahub.com/cookieconsent/opendatahub/cookieconsent.css
       - URL: https://fonts.testingmachine.eu/source-sans-pro/style.css
-      - URL: https://fonts.testingmachine.eu/open-sans/style.css
 
     js:
       - URL: /js/bootstrap-v5.bundle.min.js

--- a/src/config/production/params.yml
+++ b/src/config/production/params.yml
@@ -11,9 +11,9 @@ web_components:
     script_name: wcs-list-widget.min.js
     attributes:
       - key: font-url
-        value: https://fonts.testingmachine.eu/open-sans/style.css
+        value: https://fonts.testingmachine.eu/source-sans-pro/style.css
       - key: font-name
-        value: Open Sans
+        value: Source Sans Pro
 
   datasets_list_widget:
     tag_name: datasets-list-widget
@@ -21,8 +21,8 @@ web_components:
     script_name: datasets-list-widget.min.js
     attributes:
       - key: font-url
-        value: https://fonts.testingmachine.eu/open-sans/style.css
+        value: https://fonts.testingmachine.eu/source-sans-pro/style.css
       - key: font-name
-        value: Open Sans
+        value: Source Sans Pro
 
 noindex: false

--- a/src/config/testing/params.yml
+++ b/src/config/testing/params.yml
@@ -11,9 +11,9 @@ web_components:
     script_name: datasets-list-widget.min.js
     attributes:
       - key: font-url
-        value: https://fonts.testingmachine.eu/open-sans/style.css
+        value: https://fonts.testingmachine.eu/source-sans-pro/style.css
       - key: font-name
-        value: Open Sans
+        value: Source Sans Pro
 
   wcs_list_widget:
     tag_name: wcs-list-widget
@@ -21,8 +21,8 @@ web_components:
     script_name: wcs-list-widget.min.js
     attributes:
       - key: font-url
-        value: https://fonts.testingmachine.eu/open-sans/style.css
+        value: https://fonts.testingmachine.eu/source-sans-pro/style.css
       - key: font-name
-        value: Open Sans
+        value: Source Sans Pro
 
 noindex: true

--- a/src/themes/odh-fbe/layouts/community/design-guidelines/list.html
+++ b/src/themes/odh-fbe/layouts/community/design-guidelines/list.html
@@ -83,7 +83,7 @@
         <i class="fa fa-caret-up ms-1" aria-hidden="true"></i>
     </h3>
     <div class="video collapse" id="typography-content">
-        <p> The font used is Open Sans font, the body text is 16px </p>    
+        <p> The font used is Source Sans Pro font, the body text is 16px </p>    
         <div> 
             <p class="fw-bold ">CHARACTERS</p> 
         </div> 
@@ -258,7 +258,7 @@
         </p>        
         <ul><li><b>Page title</b>, placed inside a rectangle with fixed dimensions.</li>
             The font must follow these specifications:
-            <ul><li>Open Sans Bold, uppercase</li>
+            <ul><li>Source Sans Pro Bold, uppercase</li>
             <li>Body 17px with line height 20px</li>
             <li>Secondary color #000000</li>
             </ul>
@@ -267,7 +267,7 @@
             
         <ul><li><b>Navigation bar</b> with main links, which may include dropdown menus indicated by small downward arrows to display sub-items.</li>
             The font must follow these specifications:
-            <ul><li>Open Sans Regular, lowercase</li>
+            <ul><li>Source Sans Pro Regular, lowercase</li>
             <li>Body 17px</li>
             <li>Font color #212529</li>
             </ul>
@@ -298,7 +298,7 @@
             On the left, the Open Data Hub logo with the tagline "Place where data and tech are shared", placed inside a rectangle and aligned to the left.
             <br>On the right, the NOI Techpark logo with the tagline "Innovation hub in Südtirol/Alto Adige", also inside a rectangle and aligned to the left.
             <br>The font must follow these specifications:
-            <ul><li>Open Sans Bold, lowercase</li>
+            <ul><li>Source Sans Pro Bold, lowercase</li>
             <li>Body 20px, line height 35px</li>
             <li>Secondary color #000000</li>
             </ul>
@@ -307,7 +307,7 @@
         <ul><li><b>Four sections</b> arranged in columns: <b>Services</b>, <b>Quickstart</b>, <b>Community</b> and <b>Social Media</b>.</li>
             Each section contains useful links, which are underlined on hover to improve usability.
             <br>The font must follow these specifications:
-            <ul><li>Open Sans Regular & Bold (only for section titles), lowercase </li>
+            <ul><li>Source Sans Pro Regular & Bold (only for section titles), lowercase </li>
                 <li>Body 20px, line height 35px</li>
                 <li>Font color #212529</li>
             </ul>

--- a/src/themes/odh-fbe/layouts/community/design-guidelines/list.html
+++ b/src/themes/odh-fbe/layouts/community/design-guidelines/list.html
@@ -131,7 +131,7 @@
             <div class="col-lg-6">
                 <h1>H1 Heading</h1>
                 <h2>H2 Heading</h2>
-                <h3 style="font-size: 1.25rem;">H3 Heading</h3>
+                <h3>H3 Heading</h3>
                 <h4 style="font-size: 1.125rem;">H4 Heading</h4>
                 <h5 style="font-size: 1rem;">H5 Heading</h5>
             </div>

--- a/src/themes/odh-fbe/layouts/partials/generic-boxes.html
+++ b/src/themes/odh-fbe/layouts/partials/generic-boxes.html
@@ -18,7 +18,7 @@
                             </div>
                             <div class="flex-grow-1 p-3 align-items-center row">
                                 <div class="col-9 col-xs-10 col-lg-9">
-                                    <h4>{{ .name | markdownify }}</h4>
+                                    <h2>{{ .name | markdownify }}</h2>
                                     <div class="btn btn-secondary">{{ .btn_label | markdownify }}</div>
                                 </div>
                                 <div class="col-3 col-xs-2 col-lg-3">

--- a/src/themes/odh-fbe/static/css/custom.css
+++ b/src/themes/odh-fbe/static/css/custom.css
@@ -1,3 +1,4 @@
+
 /*
 SPDX-FileCopyrightText: NOI Techpark <digital@noi.bz.it>
 
@@ -54,9 +55,17 @@ h2 {
   font-size: 1.5rem;
 }
 
-/* h3 {
-  font-size: 1.5rem;
-} */
+h3 {
+  font-size: 1.25rem;
+}
+
+h4   {
+  font-size: 1.125rem;
+}
+
+h5 {
+  font-size: 1rem;
+}
 
 /* BOOTSTRAP TEXT UTILITIES OVERRIDE */
 .fw-semibold {

--- a/src/themes/odh-fbe/static/css/custom.css
+++ b/src/themes/odh-fbe/static/css/custom.css
@@ -100,8 +100,8 @@ ul.no-bullets {
 .btn {
   border: none !important;
   border-radius: var(--border-radius) !important;
-  font-size: 0.8rem;
-  font-weight: 600;
+  font-size: 0.9rem;
+  font-weight: 610;
   padding: 10px 15px;
   letter-spacing: 0;
 }

--- a/src/themes/odh-fbe/static/css/custom.css
+++ b/src/themes/odh-fbe/static/css/custom.css
@@ -21,6 +21,7 @@ html {
 
 body {
   font-family: "Source Sans Pro", Arial, sans-serif;
+  font-size: 16px;
 
   padding-top: 5rem;
 }

--- a/src/themes/odh-fbe/static/css/custom.css
+++ b/src/themes/odh-fbe/static/css/custom.css
@@ -19,7 +19,7 @@ html {
 }
 
 body {
-  font-family: "Open Sans", Arial, sans-serif;
+  font-family: "Source Sans Pro", Arial, sans-serif;
 
   padding-top: 5rem;
 }
@@ -137,8 +137,8 @@ ul.no-bullets {
 }
 
 /* Footer */
-footer * {    
-  font-family: "Source Sans Pro", "Open Sans", arial, sans-serif;
+footer * {
+  font-family: "Source Sans Pro", Arial, sans-serif;
   font-size: 20px;
   line-height: 28px;
   color: #3C4043;
@@ -408,7 +408,7 @@ footer .w-fit {
   margin: 0;
   padding: 0;
   background: none;
-  font-family: "Open Sans", Arial, sans-serif;
+  font-family: "Source Sans Pro", Arial, sans-serif;
   font-size: 1.5em;
   font-style: italic;
   line-height: 1.4 !important;


### PR DESCRIPTION
This PR contains fixes to the following 2 issues:
[As an Open Data Hub manager I want use the font Source Sans Pro, to be inline with all other tools and the NOI default font.](https://github.com/noi-techpark/opendatahub-website/issues/283)
[As an Open Data Hub manager I want the H3 Heding properly set, to be inline with the SEO guidelines](https://github.com/noi-techpark/opendatahub-website/issues/284)

- [x] Change the font to Source Sans Pro
- [x] Create H3-H5 heading properties
- [x] Fix issues with elements that are too small
