### PR TITLE
Adapt Open Data Hub Day 2025 page to use new feature of multiple speaker / organizations and corresponding URLs

### DIFF
--- a/src/content/events/odhday25/_index.md
+++ b/src/content/events/odhday25/_index.md
@@ -153,7 +153,9 @@ content:
       - videoLink: "https://player.vimeo.com/video/1090602432"
     - cols:
       - time: "12.00"
-      - speaker: "David Spitaler, Elias Klotz"
+      - speakers:
+        - name: "David Spitaler"
+        - name: "Elias Klotz"
       - org: "TFO Bozen Max Valier"
       - orgURL: "https://www.tfobz.it/"
       - content: "Open Quiz Hub"
@@ -306,8 +308,16 @@ content:
     - cols:
       - time: "11.45"
       - track: "OTP & Mobility"
-      - speaker: "Guido Amato, Marco Comerio"
-      - org: "Lucian (OpenMove), Cefriel"
+      - speakers:
+        - name: "Guido Amato"
+          url: "https://www.linkedin.com/in/guidoamato/"
+        - name: "Marco Comerio"
+          url: "https://www.linkedin.com/in/marcocomerio/"
+      - organizations:
+        - name: "Lucian (OpenMove)"
+          url: "https://www.openmove.com/"
+        - name: "Cefriel"
+          url: "https://www.cefriel.com/"
       - content: "Facilitating the Transition from GTFS and GTFS-RT to NeTEx and SIRI in OpenTripPlanner"
       - slidesLink: https://cloud.opendatahub.com/index.php/s/cFZwsbeNbfkXFXZ
       - videoLink: "https://player.vimeo.com/video/1090650840"
@@ -402,8 +412,16 @@ content:
     - cols:
       - time: "15.30"
       - track: "Core Technologies"
-      - speaker: "Davide Montesin, Chris Mair"
-      - org: "Catch Solve, 1006.org"
+      - speakers:
+        - name: "Davide Montesin"
+          url: "https://www.linkedin.com/in/davidemontesin"
+        - name: "Chris Mair"
+          url: "https://www.linkedin.com/in/chris-mair/"
+      - organizations:
+        - name: "Catch Solve"
+          url: "https://www.catch-solve.tech/en/home"
+        - name: "1006.org"
+          url: "https://www.1006.org/"
       - content: "Automated Data Quality Testing Tool"
       - slidesLink: https://cloud.opendatahub.com/index.php/s/P3697tonnFxMwtK
       - videoLink: "https://player.vimeo.com/video/1090752911"
@@ -420,7 +438,11 @@ content:
     - cols:
       - time: "16.00"
       - track: "Core Technologies"
-      - speaker: "Simone Pandini, Manuela Corte Pause"
+      - speakers:
+        - name: "Simone Pandini"
+          url: "https://www.linkedin.com/in/simone-pandini-bb5875345"
+        - name: "Manuela Corte Pause"
+          url: "https://www.linkedin.com/in/manuela-corte-pause"
       - org: "Ontopic"
       - orgURL: "https://ontopic.ai/"
       - content: "Using Natural Language For Interacting With The Open Data Hub"
@@ -438,7 +460,9 @@ content:
     - cols:
       - time: "16.30"
       - track: "Core Technologies"
-      - speaker: "Martin Rabanser, Marco Dalle Feste"
+      - speakers:
+        - name: "Martin Rabanser"
+        - name: "Marco Dalle Feste"
       - org: "AlpineBits Alliance"
       - orgURL: "https://www.alpinebits.org/"
       - content: "AlpineBits: certifying an Open Standard"


### PR DESCRIPTION
Now the following presentations of the **Open Data Hub Day - Programme** have multiple speaker / multiple organisations assigned:

- Open Quiz Hub
- Using Natural Language For Interacting With The Open Data Hub
- AlpineBits: certifying an Open Standard
- Facilitating the Transition from GTFS and GTFS-RT to NeTEx and SIRI in OpenTripPlanner
- Automated Data Quality Testing Tool