### PR TITLE
Homepage update - reduced spacing

### DIFF
--- a/src/themes/odh-fbe/layouts/index.html
+++ b/src/themes/odh-fbe/layouts/index.html
@@ -16,8 +16,8 @@
 	{{ partial "text-imgs.html" site.Data.home.use_case_data_access }}
 </div>
 
-{{ partial "imgs-text.html" site.Data.home.use_case_data_sharing }} -->
-{{ partial "imgs-text.html" site.Data.home.use_case }}
+{{ partial "imgs-text.html" site.Data.home.use_case_data_sharing }} 
+{{ partial "imgs-text.html" site.Data.home.use_case }}-->
 {{ partial "imgs-text.html" site.Data.home.community_event }}
 
 


### PR DESCRIPTION
This PR reduces the spacing between the Services section and the Open Data Hub Day tab, added by mistake during the last changes in the homepage
