### PR TITLE
fix open data hub bootcamp 2025 now using corrected template

### DIFF
--- a/src/content/events/bootcamp25/_index.md
+++ b/src/content/events/bootcamp25/_index.md
@@ -1,6 +1,6 @@
 ---
 type: events/single
-content_partial: table-program-press-release
+content_partial: table-program
 position: "Events"
 url: "/events/bootcamp25"
 aliases:
@@ -9,15 +9,17 @@ aliases:
   - "/bootcamp25"
 
 title: "Open Data Hub Bootcamp 2025"
-subtitle: "Welcome to the third edition of the Open Data Hub Bootcamp! This event is an initiative of the Open Data Hub team in collaboration with the Faculty of Engineering of the Free University of Bozen-Bolzano. It offers the Open Data Hub community, students and anyone interested the opportunity to develop or improve the Open Data Hub together with the core team, following the latest trends in learning by doing.
+subtitle: |
+  Welcome to the third edition of the Open Data Hub Bootcamp! This event is an initiative of the Open Data Hub team in collaboration with the Faculty of Engineering of the Free University of Bozen‑Bolzano. It offers the Open Data Hub community, students and anyone interested the opportunity to develop or improve the Open Data Hub together with the core team, following the latest trends in learning by doing.
 
-Whether you are a developer, creator, designer, data expert, entrepreneur, tech enthusiast or just someone who loves coding, we encourage you to get involved in the next edition of the event!
-"
+  Whether you are a developer, creator, designer, data expert, entrepreneur, tech enthusiast or just someone who loves coding, we encourage you to get involved in the next edition of the event!
 
 program:
   title: "Open Data Hub Bootcamp 2025 - Schedule"
-  subtitle: "The event will take place on **8th April** at NOI Techpark in Bolzano/Bozen, Italy. Participants will work in teams to collaborate, communicate, learn from each other and share best practices. The focus will be on solving real business challenges through teamwork.
-The event will be held in **English**. Participation is **free of charge**."
+  subtitle: |
+    The event will take place on **8th April** at NOI Techpark in Bolzano/Bozen, Italy. Participants will work in teams to collaborate, communicate, learn from each other and share best practices. The focus will be on solving real business challenges through teamwork.
+
+    The event will be held in **English**. Participation is **free of charge**.
 
 content:
   title: Register here
@@ -27,53 +29,48 @@ content:
 
   header:
     - title: Time
-      width: 10%
-    - title: 
-      width: 5px
-    - title: 
-      width: 5px
+      width: 20%
     - title: Title
-      width: 40%
-    - title: "Slides"
-      width: 5%
-    - title: "Video"
-      width: 5%  
+      width: 70%
+    - title: Slides
+      width: 10%
+
   row:
     - cols:
-        - time: "8.30"
+        - content: "8.30"
         - content: "Registration/check-in"
     - cols:
-        - time: "9.00"
-        - content: Welcome
+        - content: "9.00"
+        - content: "Welcome"
         - slidesLink: "https://cloud.opendatahub.com/index.php/s/Z4HSeFfsi4dM4j9"
     - cols:
-        - time: "9.15"
-        - content: Open Data Hub introduction, topic presentation
+        - content: "9.15"
+        - content: "Open Data Hub introduction, topic presentation"
         - slidesLink: "https://cloud.opendatahub.com/index.php/s/JWi9fSW6bmdaQEE"
     - cols:
-        - time: "9.45"
-        - content: Presentation round & team building
+        - content: "9.45"
+        - content: "Presentation round & team building"
     - cols:
-        - time: "10.00"
-        - content: Development Tips for your Bootcamp Project
+        - content: "10.00"
+        - content: "Development Tips for your Bootcamp Project"
         - slidesLink: "https://cloud.opendatahub.com/index.php/s/bJDPPXDfJwy2Ncf"
     - cols:
-        - time: "10.15"
+        - content: "10.15"
         - content: "Warm-up development"
     - cols:
-        - time: "12.00"
+        - content: "12.00"
         - content: "Pitch"
     - cols:
-        - time: "12.30"
+        - content: "12.30"
         - content: "Lunch break"
     - cols:
-        - time: "13.30"
+        - content: "13.30"
         - content: "Development time"
     - cols:
-        - time: "17.30"
+        - content: "17.30"
         - content: "Final pitch"
     - cols:
-        - time: "18.00"
+        - content: "18.00"
         - content: "Aperitivo"
 
   btn_down_link: "https://cloud.opendatahub.com/index.php/s/rifxJJ9NCxSicyb"


### PR DESCRIPTION
The issue was that the Open Data Hub Bootcamp 2025 did not render the table data correctly, as shown in the image below:

<img width="977" height="906" alt="image" src="https://github.com/user-attachments/assets/9564a7bd-7ee4-40e3-ad1f-d60e48232c5d" />

This happened because the Bootcamp page was using the `table-program-press-release` partial, the template for Open Data Hub Day, instead of the correct `table-program` template. To fix it, I updated the page to use `table-program` and made a few minor corrections to the front matter.

There was also a syntax error in the line breaks for both `subtitle` fields, which I have fixed.

Now the Bootcamp 2025-page renders correctly and in the same way as other Bootcamp pages:

https://github.com/user-attachments/assets/3f642408-76a6-4545-8e98-a4341372647f

