### PR TITLE
Contributors rst workflow precommit

### DIFF
--- a/.github/workflows/contributors-check.yml
+++ b/.github/workflows/contributors-check.yml
@@ -1,0 +1,23 @@
+name: Contributors up-to-date check
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+      - name: Verify CONTRIBUTORS.rst
+        shell: bash
+        run: |
+          git fetch origin +refs/heads/main:refs/remotes/origin/main
+          tmp="$(mktemp)"
+          trap 'rm -f "$tmp"' EXIT
+          cp CONTRIBUTORS.rst "$tmp"
+          bash CONTRIBUTORS.rst
+          if ! cmp --silent CONTRIBUTORS.rst "$tmp"; then
+            echo "Contributors not up to date. please run CONTRIBUTORS.rst before committing"
+            git --no-pager diff --no-index --unified=2 --word-diff -- "$tmp" CONTRIBUTORS.rst || true
+            exit 1
+          fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,25 @@
 repos:
--   repo: https://github.com/fsfe/reuse-tool
-    rev: v5.0.0
-    hooks:
-    - id: reuse
+- repo: https://github.com/fsfe/reuse-tool
+  rev: v5.0.0
+  hooks:
+  - id: reuse
+
+- repo: local
+  hooks:
+  - id: contributors-up-to-date
+    name: contributors-up-to-date
+    language: system
+    entry: bash -lc
+    args:
+      - |
+        tmp="$(mktemp)"
+        trap 'rm -f "$tmp"' EXIT
+        cp CONTRIBUTORS.rst "$tmp"
+        bash CONTRIBUTORS.rst
+        if ! cmp --silent CONTRIBUTORS.rst "$tmp"; then
+            echo "Contributors not up to date. please run CONTRIBUTORS.rst before committing"
+            git --no-pager diff --no-index --unified=2 --word-diff -- "$tmp" CONTRIBUTORS.rst || true
+            exit 1
+        fi
+    pass_filenames: false
+    stages: [pre-commit]


### PR DESCRIPTION
This pull request introduces automated checks to ensure that the `CONTRIBUTORS.rst` file is always up-to-date, both in CI workflows and during local development. The main changes add a GitHub Actions workflow and a new pre-commit hook that verify the contributors list is current before changes are committed or merged.

**Automation for contributor file consistency:**

* Added a new GitHub Actions workflow `.github/workflows/contributors-check.yml` that runs on every push and pull request to verify `CONTRIBUTORS.rst` is up-to-date by executing a script and comparing changes.
* Introduced a local pre-commit hook in `.pre-commit-config.yaml` to perform the same contributor check before commits are made, helping developers catch issues early.