### PR TITLE
add twitter social cards support

### DIFF
--- a/src/themes/odh-fbe/layouts/partials/header.html
+++ b/src/themes/odh-fbe/layouts/partials/header.html
@@ -36,6 +36,7 @@
 {{ end }}
 
 {{ template "_internal/opengraph.html" . }}
+{{ template "_internal/twitter_cards.html" . }}
 
 <!-- Matomo -->
 <script type="text/plain" data-cookiecategory="targeting">


### PR DESCRIPTION
Hi @sseppi,

I added the required header to include images in the shared Twitter (X) cards.  
The logic is the same as for the other cards: if no image is specified on a page, it will use the default Open Data Hub logo.  

This is how links from the Open Data Hub website are now rendered on Twitter (X):

<img width="415" height="318" alt="image" src="https://github.com/user-attachments/assets/fb6a9b1e-411f-462d-a356-70bb5d5ec199" />
