### PR TITLE
fix typos in icon names

### DIFF
--- a/src/themes/odh-fbe/layouts/community/design-guidelines/list.html
+++ b/src/themes/odh-fbe/layouts/community/design-guidelines/list.html
@@ -304,7 +304,7 @@
         <img src="/icon/Automated.svg" data-bs-toggle="tooltip" title="Automated" alt title/>
         <img src="/icon/clock.svg" data-bs-toggle="tooltip" title="Clock" alt title/>
         <img src="/icon/Dataanalyst.svg" data-bs-toggle="tooltip" title="Data Analyst" alt title/>
-        <img src="/icon/database.svg" data-bs-toggle="tooltip" title="Database" alt title/>
+        <img src="/icon/Database.svg" data-bs-toggle="tooltip" title="Database" alt title/>
         <img src="/icon/Developer.svg" data-bs-toggle="tooltip" title="Developer" alt title/>
         <img src="/icon/Event.svg" data-bs-toggle="tooltip" title="Event" alt title/>
         <img src="/icon/Large.svg" data-bs-toggle="tooltip" title="Large" alt title/>
@@ -316,7 +316,7 @@
         <img src="/icon/Turist.svg" data-bs-toggle="tooltip" title="Tourist" alt title/>
         <img src="/icon/weather.svg" data-bs-toggle="tooltip" title="Weather" alt title/>
         <img src="/icon/wine.svg" data-bs-toggle="tooltip" title="Wine" alt title/>
-        <img src="/icon/webcam.svg" data-bs-toggle="tooltip" title="Webcam" alt title/>
+        <img src="/icon/Webcam.svg" data-bs-toggle="tooltip" title="Webcam" alt title/>
     </div>
     <div class="d-flex mb-3 gap-3">
         <img src="/icon/Adress.svg" data-bs-toggle="tooltip" title="Address" alt title/>


### PR DESCRIPTION
Hi @sseppi,  
I found two typos in the icon names that caused them not to show up in the guidelines.  
They are fixed now.  

<img width="2147" height="313" alt="image" src="https://github.com/user-attachments/assets/367a77ce-3440-4dfd-bd7a-6dbde22b67f3" />


Cheers,  
Lukas

