### PR TITLE
chore: add gsoc under community navbar

### DIFF
--- a/src/config/_default/config.yml
+++ b/src/config/_default/config.yml
@@ -250,6 +250,10 @@ menu:
       URL: /community/get-involved
       weight: 6
 
+    - parent: community
+      name: GSoC 2026
+      URL: /gsoc26/
+      weight: 7
 
     # --- Events ---
     - identifier: events

--- a/src/content/gsoc26/contributor_guidance.md
+++ b/src/content/gsoc26/contributor_guidance.md
@@ -11,7 +11,7 @@ This page serves as your starting point for participating in Open Data Hub proje
 
 ## Contents
 
-- [Organisation Administrators](#gsoc-open-data-hub-administrators) (Org Admin)
+- [Organisation Administrators](#gsoc-open-data-hub-administrators) (Org Admins)
 - [Mentors](#gsoc-open-data-hub-mentors)
 - [Mentors Information and Guide](#mentors-information-and-guide)
 - [Contributor's Guide](#contributors-guide)


### PR DESCRIPTION
Hi @sseppi ,
I added gsoc26 to the drop down of community so that users can access it from the main page of Open Data Hub website and corrected a typo in the contributor guidance page. 
Please review and merge when you have a moment.
