### PR TITLE
Add Code of Conduct document

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,9 @@
+# Code of Conduct
+
+Hello everyone,
+
+We’re sharing the Code of Conduct for Open Data Hub to ensure a respectful, inclusive, and collaborative environment for all members. We kindly ask everyone to take a few minutes to carefully review the document linked below and familiarize themselves with the guidelines.
+
+By being part of this community, you agree to follow these principles and help maintain a positive space for everyone.
+
+https://cloud.opendatahub.com/index.php/s/BTiqmMyQM4q45TN


### PR DESCRIPTION
This pull request adds the Code of Conduct for the Open Data Hub project.

It includes an introductory section in the repository along with a link to the full Code of Conduct document hosted on Nextcloud. The goal is to ensure all contributors and community members are aware of the expected standards of behavior and help maintain a respectful, inclusive, and collaborative environment.
