### PR TITLE
Add Code of Conduct for Open Data Hub

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,7 +1,6 @@
-SPDX-License-Identifier: AGPL-3.0-only
-
 <!--
-SPDX-FileCopyrightText: 2026 Open Data Hub
+SPDX-FileCopyrightText: NOI Techpark
+SPDX-License-Identifier: CC0-1.0
 -->
 
 # Code of Conduct

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,9 +1,9 @@
-# Code of Conduct
-
 <!--
 SPDX-FileCopyrightText: 2026 Open Data Hub
 SPDX-License-Identifier: AGPL-3.0-only
 -->
+
+# Code of Conduct
 
 Hello everyone,
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,14 @@
+# Code of Conduct
+
+<!--
+SPDX-FileCopyrightText: 2026 Open Data Hub
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
+Hello everyone,
+
+We’re sharing the Code of Conduct for Open Data Hub to ensure a respectful, inclusive, and collaborative environment for all members. We kindly ask everyone to take a few minutes to carefully review the document linked below and familiarize themselves with the guidelines.
+
+By being part of this community, you agree to follow these principles and help maintain a positive space for everyone.
+
+https://cloud.opendatahub.com/index.php/s/BTiqmMyQM4q45TN

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,7 @@
+SPDX-License-Identifier: AGPL-3.0-only
+
 <!--
 SPDX-FileCopyrightText: 2026 Open Data Hub
-SPDX-License-Identifier: AGPL-3.0-only
 -->
 
 # Code of Conduct


### PR DESCRIPTION
This PR adds the Code of Conduct for the Open Data Hub project.

It includes an introduction and a link to the full document, and ensures REUSE license compliance.