### PR TITLE
Fix spelling mistakes in OpenTripPlanner landing page

### DIFF
--- a/src/content/quickstart/opentripplanner/_index.md
+++ b/src/content/quickstart/opentripplanner/_index.md
@@ -2,7 +2,7 @@
 type: quickstart/single
 position: "Resources"
 title: "**OpenTripPlanner (OTP)**"
-subtitle: "Help your customer, to plan their journey effortlessly with integrating the data offereb by the Open Data Hub multi-modal transit planner API in your application. The Open Data Hub OTP API combines data from different surces like for example public transport, cycling, and walking routes etc., to elaborate the best path."
+subtitle: "Help your customer, to plan their journey effortlessly with integrating the data offered by the Open Data Hub multi-modal transit planner API in your application. The Open Data Hub OTP API combines data from different sources like for example public transport, cycling, and walking routes etc., to elaborate the best path."
 
 rows:
 


### PR DESCRIPTION
This PR fixes the spelling mistakes identified in the OpenTripPlanner landing page after reviewing the version deployed on the testing machine.

- Corrected spelling errors in the introductory description.
