### PR TITLE
Geo api doc

### DIFF
--- a/src/data/api.yml
+++ b/src/data/api.yml
@@ -59,6 +59,21 @@ apis:
         url: "https://docs.opendatahub.com/use-data/transmodel-api/reference#2-siri-lite-endpoints"
         target_blank: true
 
+  - title: "GEO API"
+    description: "Access Open Data Hub geospatial data through the GEO API."
+    category: "project_specific"
+    buttons:
+      - label: "Swagger"
+        url: "https://geo.api.opendatahub.com/swagger/index.html"
+        target_blank: true
+      - label: "Repository"
+        url: "https://github.com/noi-techpark/opendatahub-geo-api"
+        target_blank: true
+      - label: "Documentation"
+        url: ""
+        target_blank: true
+        
+
   - title: "AlpineBits HotelData"
     description: "Access accommodation inventory data via the Open Data Hub AlpineBits HotelData API."
     category: "project_specific"

--- a/src/data/quickstart.yml
+++ b/src/data/quickstart.yml
@@ -77,5 +77,10 @@ boxes:
     btn_link: https://github.com/noi-techpark/it.bz.opendatahub.analytics.libs/tree/main/api/R
     target_blank: true
 
+  - title: GEO API
+    subtitle: Access Open Data Hub geospatial data through the GEO API.
+    btn_link: https://geo.api.opendatahub.com/swagger/index.html
+    target_blank: true
+
   
     


### PR DESCRIPTION
On the resources page, I added a new card named "GEO-API" with a learn more button that leads to the swagger
On the APIs page,  under "Other standards APIs", a new card "GEO-API" with three buttons: swagger, repository and documentation.

The documentation link does not point to anywhere currently because the documentation for this has not been put into production yet. 

Sorry for the delay. I thought once the merge was made for the docs section, it would be online for me to put the link into the documentation link on the opendatahub website.