### PR TITLE
added a link to the GEO API to the documentation

### DIFF
--- a/src/data/api.yml
+++ b/src/data/api.yml
@@ -70,7 +70,7 @@ apis:
         url: "https://github.com/noi-techpark/opendatahub-geo-api"
         target_blank: true
       - label: "Documentation"
-        url: ""
+        url: "https://docs.opendatahub.com/use-data/geo-api/reference/"
         target_blank: true
         
 


### PR DESCRIPTION
Under the resources section on the Open Data Hub website, I added the link to the official documentation for the GEO API.