### PR TITLE
Fixed button label in documentation page

### DIFF
--- a/src/data/documentation.yml
+++ b/src/data/documentation.yml
@@ -6,5 +6,5 @@ boxes:
   - title: Documentation
     subtitle: Explore the collection of the tecnical documentation about the Open Data Hub project.
     btn_link: https://docs.opendatahub.com
-    btn_label: "label"
+    btn_label: "Learn more"
     target_blank: true


### PR DESCRIPTION
@Luscha, the button label on the documentation page was just "label"; I changed it to "Learn more". Stefano said you would merge it.