### PR TITLE
fixed typo + added DATEXII (swagger and repo info)

### DIFF
--- a/src/data/api.yml
+++ b/src/data/api.yml
@@ -105,7 +105,7 @@ apis:
       target_blank: true
 
   - title: "GBFS"
-    description: "Retrive a single access point to Open Data Hub GBFS feeds and metadata."
+    description: "Retrieve a single access point to Open Data Hub GBFS feeds and metadata."
     category: "project_specific"
     buttons:
       - label: "Swagger"
@@ -122,3 +122,14 @@ apis:
       - label: "Learn more"
         url: "/quickstart/opentripplanner/"
         target_blank: false
+
+  - title: "DATEX II API"
+    description: "Access traffic event data in the European standard DATEX II XML format."
+    category: "project_specific"
+    buttons:
+      - label: "Swagger"
+        url: "https://datex.api.opendatahub.com/"
+        target_blank: true
+      - label: "Repository"
+        url: " https://github.com/noi-techpark/opendatahub-datex2"
+        target_blank: true


### PR DESCRIPTION
@clezag, for now, I just added the Swagger and Repo links to the new card on the website:
<img width="874" height="450" alt="image" src="https://github.com/user-attachments/assets/4da26c7c-91c1-48e8-83d7-5887c5321b7e" />
If you want, you can merge this while I work on the documentation, which will take a couple of days.